### PR TITLE
fixed decode.cpp undefined behaviour

### DIFF
--- a/decode.cpp
+++ b/decode.cpp
@@ -121,7 +121,9 @@ static value parse_dict(Iter& beg, const Iter& end)
 	
 	value::dict_type dict;
 	while (beg != end && *beg != 'e') {
-		dict[decode(beg, end)] = decode(beg, end);
+		value first = decode(beg, end);
+		value second = decode(beg, end);
+		dict[first] = second;
 	}
 	if (beg == end || *beg != 'e') {
 		throw std::runtime_error("Dicts must be suffixed by e");


### PR DESCRIPTION
Order of evaluation of assignment arguments is undefined behaviour.
This code produced reversed maps (`dict[value] = key`) when compiled with `gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)`.
